### PR TITLE
Avoid unnecessary libvirt network updates on DNS diffs

### DIFF
--- a/libvirt_aws/__main__.py
+++ b/libvirt_aws/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/libvirt_aws/handlers/_routing.py
+++ b/libvirt_aws/handlers/_routing.py
@@ -221,16 +221,25 @@ def direct_handler(
                     error_formatter=error_formatter,
                     include_request_id=False,
                 )
-                if (method, path) not in _path_handlers:
-                    routes.route(method, path)(
-                        functools.partial(
-                            handle_request,
-                            action=action,
+                paths = [path]
+                if path != "/":
+                    if path.endswith("/"):
+                        paths.append(path.rstrip("/"))
+                    else:
+                        paths.append(f"{path}/")
+                for p in paths:
+                    if (method, p) not in _path_handlers:
+                        routes.route(method, p)(
+                            functools.partial(
+                                handle_request,
+                                action=action,
+                            )
                         )
-                    )
-                    _path_handlers.add((method, path))
-                else:
-                    raise AssertionError(f"{method} {path} is already handled")
+                        _path_handlers.add((method, p))
+                    else:
+                        raise AssertionError(
+                            f"{method} {p} is already handled"
+                        )
             else:
                 raise AssertionError(f"{method} {action} is already handled")
         return handler

--- a/libvirt_aws/handlers/_routing.py
+++ b/libvirt_aws/handlers/_routing.py
@@ -67,7 +67,6 @@ def format_xml_response(
 
 
 class ServiceError(web.HTTPError):
-
     code: str
 
     def __init__(
@@ -109,22 +108,18 @@ class NotFoundError(ServiceError, web.HTTPNotFound):
 
 
 class InvalidActionError(ClientError):
-
     code = "InvalidAction"
 
 
 class InvalidMethodError(ServiceError, web.HTTPMethodNotAllowed):
-
     code = "InvalidAction"
 
 
 class InvalidParameterError(ClientError):
-
     code = "InvalidParameterValue"
 
 
 class IncorrectStateError(ClientError):
-
     code = "IncorrectState"
 
 
@@ -133,7 +128,6 @@ class ServerError(ServiceError, web.HTTPInternalServerError):
 
 
 class InternalServerError(ServerError):
-
     code = "InternalError"
 
 
@@ -212,7 +206,6 @@ def direct_handler(
     list_format: Literal["condensed", "expanded"] = "expanded",
     error_formatter: Callable[[ServiceError], str] = format_ec2_error_xml,
 ) -> Callable[[_HandlerType], _HandlerType]:
-
     if isinstance(methods, str):
         methods = (methods,)
 

--- a/libvirt_aws/handlers/dns.py
+++ b/libvirt_aws/handlers/dns.py
@@ -39,32 +39,26 @@ def format_route53_error_xml(err: _routing.ServiceError) -> str:
 
 
 class NoSuchHostedZoneError(_routing.NotFoundError):
-
     code = "NoSuchHostedZone"
 
 
 class InvalidInputError(_routing.ClientError):
-
     code = "InvalidInput"
 
 
 class InvalidDomainNameError(_routing.ClientError):
-
     code = "InvalidDomainName"
 
 
 class HostedZoneNotEmptyError(_routing.ClientError):
-
     code = "HostedZoneNotEmpty"
 
 
 class InvalidChangeBatchError(_routing.ClientError):
-
     code = "InvalidChangeBatch"
 
 
 class NoSuchChangeError(_routing.NotFoundError):
-
     code = "NoSuchChange"
 
 
@@ -379,7 +373,9 @@ async def list_hosted_zones_by_name(
         try:
             max_items = int(max_items_str)
         except ValueError:
-            raise _routing.InvalidParameterError("maxitems must be an integer")
+            raise _routing.InvalidParameterError(
+                "maxitems must be an integer"
+            ) from None
 
         if max_items > 100:
             raise _routing.InvalidParameterError(
@@ -703,7 +699,7 @@ async def list_resource_record_sets(
         try:
             limit = int(limit)
         except (TypeError, ValueError):
-            raise InvalidInputError("invalid MaxItems value")
+            raise InvalidInputError("invalid MaxItems value") from None
 
     return {
         "ResourceRecordSets": [

--- a/libvirt_aws/handlers/errors.py
+++ b/libvirt_aws/handlers/errors.py
@@ -4,5 +4,4 @@ from . import _routing
 
 
 class InvalidInstanceID_NotFound(_routing.ClientError):
-
     code = "InvalidInstanceID.NotFound"

--- a/libvirt_aws/handlers/ips.py
+++ b/libvirt_aws/handlers/ips.py
@@ -28,27 +28,22 @@ PUBLIC_IP_BLOCK_SIZE = 16
 
 
 class AddressLimitExceededError(_routing.ClientError):
-
     code = "AddressLimitExceeded"
 
 
 class InvalidAddressID_NotFound(_routing.ClientError):
-
     code = "InvalidAddressID.NotFound"
 
 
 class InvalidAddress_NotFound(_routing.ClientError):
-
     code = "InvalidAddress.NotFound"
 
 
 class InvalidAddress_InUse(_routing.ClientError):
-
     code = "InvalidIPAddress.InUse"
 
 
 class InvalidAssociationID_NotFound(_routing.ClientError):
-
     code = "InvalidAssociationID.NotFound"
 
 
@@ -623,7 +618,7 @@ async def assign_private_ip_addresses(
     except ValueError:
         raise _routing.InvalidParameterError(
             "SecondaryPrivateIpAddressCount must be a positive integer"
-        )
+        ) from None
 
     if addr_count <= 0:
         raise _routing.InvalidParameterError(
@@ -841,7 +836,7 @@ async def describe_network_ifaces(
             raise _routing.InternalServerError(
                 f"could not decode output of `ip addr list` in VM: \n"
                 f"{e}\nOUTPUT:\n{output_str}"
-            )
+            ) from e
 
         for iface in ip_output:
             if iface.get("link_type") != "ether":

--- a/libvirt_aws/handlers/volumes.py
+++ b/libvirt_aws/handlers/volumes.py
@@ -18,12 +18,10 @@ from .. import objects
 
 
 class InvalidAttachmentNotFound(_routing.ClientError):
-
     code = "InvalidAttachment.NotFound"
 
 
 class InvalidVolumeNotFound(_routing.ClientError):
-
     code = "InvalidVolume.NotFound"
 
 
@@ -379,7 +377,8 @@ async def modify_volume(
             size_gb = int(size)
         except ValueError:
             raise _routing.InvalidParameterError(
-                "invalid Size value") from None
+                "invalid Size value"
+            ) from None
 
         vol_info = _describe_volume(pool, vol)
 
@@ -393,14 +392,15 @@ async def modify_volume(
                     try:
                         domain.blockResize(
                             os.path.basename(att["device"]),
-                            size_gb * 2 ** 30,
+                            size_gb * 2**30,
                             libvirt.VIR_DOMAIN_BLOCK_RESIZE_BYTES,
                         )
                     except libvirt.libvirtError as e:
                         result["modificationState"] = "failed"
                         result["statusMessage"] = str(e)
                         app["logger"].exception(
-                            "could not resize attached volume")
+                            "could not resize attached volume"
+                        )
 
         else:
             try:
@@ -408,12 +408,11 @@ async def modify_volume(
             except libvirt.libvirtError as e:
                 raise InvalidVolumeNotFound(f"invalid VolumeId: {e}") from e
             try:
-                virvol.resize(size_gb * 2 ** 30)
+                virvol.resize(size_gb * 2**30)
             except libvirt.libvirtError as e:
                 result["modificationState"] = "failed"
                 result["statusMessage"] = str(e)
-                app["logger"].exception(
-                    "could not resize detached volume")
+                app["logger"].exception("could not resize detached volume")
 
     end_time = datetime.datetime.now(datetime.timezone.utc)
     result["endTime"] = end_time.strftime("%Y-%m-%dT%H:%M:%S.%f000Z")
@@ -510,7 +509,6 @@ def _describe_volume(
     pool: libvirt.virStoragePool,
     volume: objects.Volume,
 ) -> Dict[str, Any]:
-
     attachments = objects.get_vol_attachments(pool, volume)
     existing = {(att.volume, att.domain) for att in attachments}
 

--- a/libvirt_aws/main.py
+++ b/libvirt_aws/main.py
@@ -122,14 +122,7 @@ def init_app(
     database: str,
     region: str,
 ) -> web.Application:
-    app = web.Application(
-        middlewares=[
-            web.normalize_path_middleware(
-                append_slash=False,
-                remove_slash=True,
-            )
-        ]
-    )
+    app = web.Application()
     # logging.basicConfig(level=logging.DEBUG)
     aiohttp.log.access_logger.setLevel(logging.DEBUG)
     app["libvirt"] = libvirt.open(libvirt_uri)

--- a/libvirt_aws/objects.py
+++ b/libvirt_aws/objects.py
@@ -14,14 +14,12 @@ from typing import (
 import collections
 import functools
 import ipaddress
-import types
 
 import libvirt
 import xmltodict
 
 
 def get_volume(pool: libvirt.virStoragePool, name: str) -> Volume:
-
     for virvol in pool.listAllVolumes():
         vol = volume_from_xml(virvol.XMLDesc(0))
         if vol.name == name:
@@ -45,7 +43,6 @@ def get_all_volumes(
 def get_all_domains(
     conn: libvirt.virConnect,
 ) -> List[Domain]:
-
     domains = []
 
     for virdom in conn.listAllDomains():
@@ -59,7 +56,6 @@ def get_vol_attachments(
     pool: libvirt.virStoragePool,
     volume: Volume,
 ) -> List[VolumeAttachment]:
-
     conn = pool.connect()
     attachments = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,16 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["black~=22.3.0", "flake8~=4.0.1", "mypy~=0.960"]
+dev = [
+    "ruff~=0.6.4",
+    "flake8~=4.0.1",
+    "mypy~=0.960",
+    "boto3~=1.35.0",
+    "boto3-stubs[route53]~=1.35.0",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-random-order",
+]
 
 [project.scripts]
 libvirt-aws = "libvirt_aws.main:main"
@@ -29,7 +38,7 @@ line-length = 79
 target-version = ["py39"]
 
 [tool.mypy]
-files = "libvirt_aws"
+files = ["libvirt_aws", "tests"]
 python_version = "3.9"
 follow_imports = "normal"
 ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,11 @@ strict = true
 
 [tool.versioningit.write]
 file = "libvirt_aws/_version.py"
+
+[tool.ruff]
+lint.select = ["E", "F", "W", "B"]
+lint.ignore = [
+    "F541", # f-string without any placeholders
+]
+line-length = 79
+indent-width = 4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+from fixtures.boto3 import route53  # noqa
+from fixtures.libvirt_aws import server  # noqa
+from fixtures.libvirt_net import libvirt_net  # noqa

--- a/tests/fixtures/boto3.py
+++ b/tests/fixtures/boto3.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import (
+    TYPE_CHECKING,
+)
+
+import subprocess
+
+import boto3
+import pytest
+
+if TYPE_CHECKING:
+    import mypy_boto3_route53
+
+
+@pytest.fixture(scope="module")
+def route53(
+    server: subprocess.Popen[bytes],
+) -> mypy_boto3_route53.Route53Client:
+    session = boto3.session.Session(
+        aws_access_key_id="foo",
+        aws_secret_access_key="bar",
+        region_name="us-east-2",
+    )
+    return session.client("route53", endpoint_url="http://127.0.0.1:6666")

--- a/tests/fixtures/libvirt_aws.py
+++ b/tests/fixtures/libvirt_aws.py
@@ -1,0 +1,37 @@
+from typing import (
+    Generator,
+)
+
+import os
+import subprocess
+import sys
+import tempfile
+
+import libvirt
+import pytest
+
+
+@pytest.fixture(scope="module")
+def server(
+    libvirt_net: libvirt.virNetwork,
+) -> Generator[subprocess.Popen[bytes], None, None]:
+    """Starts the server program and returns its process"""
+    fileno, dbfile = tempfile.mkstemp()
+    os.close(fileno)
+    server_process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "libvirt_aws",
+            "--bind-to=127.0.0.1",
+            f"--libvirt-network={libvirt_net.UUIDString()}",
+            f"--database={dbfile}",
+            f"--port=6666",
+        ],
+        stdin=None,
+        stdout=None,
+        stderr=None,
+    )
+    yield server_process
+    server_process.kill()
+    os.unlink(dbfile)

--- a/tests/fixtures/libvirt_net.py
+++ b/tests/fixtures/libvirt_net.py
@@ -1,0 +1,40 @@
+from typing import (
+    Generator,
+)
+
+import libvirt
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def libvirt_net() -> Generator[libvirt.virNetwork, None, None]:
+    conn = libvirt.open("qemu:///system")
+
+    if not conn:
+        raise Exception("Failed to open a connection to the libvirtd daemon")
+
+    try:
+        net_name = "libvirt_aws_test_network"
+        net = conn.networkCreateXML(
+            f"""
+            <network>
+                <name>{net_name}</name>
+                <forward mode='nat' />
+                <ip address='10.11.12.1' netmask='255.255.255.0' />
+                <domain name='internal' localOnly='yes'/>
+                <dns enable='yes'/>
+            </network>
+            """,
+        )
+
+        if net is None:
+            raise Exception(
+                f"Failed to create network: {conn.lastErrorName()}"
+            )
+
+        yield net
+
+    finally:
+        net.destroy()
+        conn.close()

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = module
+
+log_cli = 1
+log_level = INFO
+log_format = %(asctime)s [%(levelname)s] %(message)s

--- a/tests/test_dns.py
+++ b/tests/test_dns.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+from typing import (
+    Generator,
+    TYPE_CHECKING,
+)
+
+import time
+
+import pytest
+
+if TYPE_CHECKING:
+    from mypy_boto3_route53 import Route53Client
+    from mypy_boto3_route53.literals import (
+        ChangeActionType,
+        RRTypeType,
+    )
+    from mypy_boto3_route53.type_defs import (
+        ChangeBatchTypeDef,
+        ResourceRecordTypeDef,
+        ResourceRecordSetOutputTypeDef,
+    )
+
+
+@pytest.fixture(scope="module")
+def hosted_zone(
+    route53: Route53Client,
+) -> Generator[str, None, None]:
+    response = route53.create_hosted_zone(
+        Name="local-1.internal.", CallerReference=str(time.time())
+    )
+    zone_id = response["HostedZone"]["Id"].split("/")[-1]
+    yield zone_id
+    record_sets = route53.list_resource_record_sets(HostedZoneId=zone_id)
+    change_batch: ChangeBatchTypeDef = {
+        "Changes": [
+            {
+                "Action": "DELETE",
+                "ResourceRecordSet": {
+                    "Name": r["Name"],
+                    "Type": r["Type"],
+                    "TTL": r["TTL"],
+                    "ResourceRecords": r["ResourceRecords"],
+                },
+            }
+            for r in record_sets["ResourceRecordSets"]
+            if (
+                r["Type"] != "SOA"
+                and (r["Type"] != "NS" or r["Name"] != "local-1.internal.")
+            )
+        ]
+    }
+    if change_batch["Changes"]:
+        route53.change_resource_record_sets(
+            HostedZoneId=zone_id,
+            ChangeBatch=change_batch,
+        )
+    route53.delete_hosted_zone(Id=zone_id)
+
+
+def _change_record_set(
+    client: Route53Client,
+    zone_id: str,
+    action: ChangeActionType,
+    name: str,
+    type: RRTypeType,
+    values: list[str],
+    ttl: int = 300,
+) -> None:
+    records: list[ResourceRecordTypeDef] = [{"Value": v} for v in values]
+    change_batch: ChangeBatchTypeDef = {
+        "Changes": [
+            {
+                "Action": action,
+                "ResourceRecordSet": {
+                    "Name": name,
+                    "Type": type,
+                    "TTL": ttl,
+                    "ResourceRecords": records,
+                },
+            }
+        ]
+    }
+    client.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch=change_batch,
+    )
+
+
+def _create_record_set(
+    client: Route53Client,
+    zone_id: str,
+    name: str,
+    type: RRTypeType,
+    values: list[str],
+    ttl: int = 300,
+) -> None:
+    _change_record_set(client, zone_id, "CREATE", name, type, values, ttl)
+
+
+def _upsert_record_set(
+    client: Route53Client,
+    zone_id: str,
+    name: str,
+    type: RRTypeType,
+    values: list[str],
+    ttl: int = 300,
+) -> None:
+    _change_record_set(client, zone_id, "UPSERT", name, type, values, ttl)
+
+
+def _delete_record_set(
+    client: Route53Client,
+    zone_id: str,
+    name: str,
+    type: RRTypeType,
+    values: list[str],
+    ttl: int = 300,
+) -> None:
+    _change_record_set(client, zone_id, "DELETE", name, type, values, ttl)
+
+
+def _get_record_set(
+    client: Route53Client,
+    zone_id: str,
+    name: str,
+    type: RRTypeType,
+) -> ResourceRecordSetOutputTypeDef | None:
+    response = client.list_resource_record_sets(
+        HostedZoneId=zone_id,
+        StartRecordName=name,
+        StartRecordType=type,
+        MaxItems="1",
+    )
+    for record in response["ResourceRecordSets"]:
+        if record["Name"] == name and record["Type"] == type:
+            return record
+    return None
+
+
+def _assert_records(
+    r1: list[ResourceRecordTypeDef],
+    r2: list[ResourceRecordTypeDef],
+) -> None:
+    r1_sorted = list(sorted(r1, key=lambda r: r["Value"]))
+    r2_sorted = list(sorted(r2, key=lambda r: r["Value"]))
+    assert r1_sorted == r2_sorted
+
+
+def _assert_record_set(
+    record: ResourceRecordSetOutputTypeDef | None,
+    values: list[str],
+) -> None:
+    assert record is not None
+    _assert_records(record["ResourceRecords"], [{"Value": v} for v in values])
+
+
+def _create_record_set_and_assert(
+    client: Route53Client,
+    zone_id: str,
+    name: str,
+    record_type: RRTypeType,
+    values: list[str],
+) -> None:
+    _create_record_set(client, zone_id, name, record_type, values)
+    record = _get_record_set(client, zone_id, name, record_type)
+    _assert_record_set(record, values)
+
+
+def _upsert_record_set_and_assert(
+    client: Route53Client,
+    zone_id: str,
+    name: str,
+    record_type: RRTypeType,
+    values: list[str],
+) -> None:
+    _upsert_record_set(client, zone_id, name, record_type, values)
+    record = _get_record_set(client, zone_id, name, record_type)
+    _assert_record_set(record, values)
+
+
+def _delete_record_set_and_assert(
+    client: Route53Client,
+    zone_id: str,
+    name: str,
+    record_type: RRTypeType,
+    values: list[str],
+) -> None:
+    _delete_record_set(client, zone_id, name, record_type, values)
+    record = _get_record_set(client, zone_id, name, record_type)
+    assert record is None
+
+
+def test_route53_A_record(
+    route53: Route53Client,
+    hosted_zone: str,
+) -> None:
+    _create_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test1.local-1.internal.",
+        "A",
+        ["192.0.2.1"],
+    )
+
+    _upsert_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test1.local-1.internal.",
+        "A",
+        ["192.0.2.1", "192.0.2.2"],
+    )
+
+    # Overlapping records.
+    _upsert_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test2.local-1.internal.",
+        "A",
+        ["192.0.2.2", "192.0.2.3"],
+    )
+
+    _upsert_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test1.local-1.internal.",
+        "A",
+        ["192.0.2.1"],
+    )
+
+
+def test_route53_AAAA_record(
+    route53: Route53Client,
+    hosted_zone: str,
+) -> None:
+    _create_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test1.local-1.internal.",
+        "AAAA",
+        ["e80::210:5aff:feaa:20a2"],
+    )
+
+    _upsert_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test1.local-1.internal.",
+        "AAAA",
+        ["e80::210:5aff:feaa:20a2", "e80::210:5aff:feaa:20b2"],
+    )
+
+    # Overlapping records.
+    _upsert_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test2.local-1.internal.",
+        "AAAA",
+        ["e80::210:5aff:feaa:20b2", "e80::210:5aff:feaa:20c2"],
+    )
+
+    _upsert_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test1.local-1.internal.",
+        "AAAA",
+        ["e80::210:5aff:feaa:20a2"],
+    )
+
+
+def test_route53_CNAME_record(
+    route53: Route53Client,
+    hosted_zone: str,
+) -> None:
+    _create_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "foo.local-1.internal.",
+        "A",
+        ["192.0.2.1"],
+    )
+
+    _create_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "bar.local-1.internal.",
+        "A",
+        ["192.0.2.2"],
+    )
+
+    _create_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "spam.local-1.internal.",
+        "A",
+        ["192.0.2.3"],
+    )
+
+    _create_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test1.local-1.internal.",
+        "CNAME",
+        ["foo.local-1.internal."],
+    )
+
+    _upsert_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test1.local-1.internal.",
+        "CNAME",
+        ["foo.local-1.internal.", "bar.local-1.internal."],
+    )
+
+    # Overlapping records.
+    _upsert_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test2.local-1.internal.",
+        "CNAME",
+        ["bar.local-1.internal.", "spam.local-1.internal."],
+    )
+
+    _upsert_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test1.local-1.internal.",
+        "CNAME",
+        ["foo.local-1.internal."],
+    )
+
+
+def test_route53_TXT_record(
+    route53: Route53Client,
+    hosted_zone: str,
+) -> None:
+    _create_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "test.local-1.internal.",
+        "TXT",
+        ['"Text1"'],
+    )
+
+
+def test_route53_SRV_record(
+    route53: Route53Client,
+    hosted_zone: str,
+) -> None:
+    _create_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "_sip._tcp.local-1.internal.",
+        "SRV",
+        ["10 5 5060 sipserver.local-1.internal."],
+    )
+
+
+def test_route53_NS_record(
+    route53: Route53Client,
+    hosted_zone: str,
+) -> None:
+    _create_record_set_and_assert(
+        route53,
+        hosted_zone,
+        "sub.local-1.internal.",
+        "NS",
+        ["ns-123.awsdns-01.com.", "ns-456.awsdns-02.net."],
+    )


### PR DESCRIPTION
The current DNS implementation generates an unnecessary large diff,
resulting in very large number of libvirt network update calls.  These
calls are expensive since they involve restarting dsnmasq and redefining
the firewall tables.  Fix this by properly generating a minimal diff.

Use the opportunity to start writing some tests.
